### PR TITLE
Inadvertent Whitespace

### DIFF
--- a/ical_dict/ical_dict.py
+++ b/ical_dict/ical_dict.py
@@ -122,9 +122,9 @@ class iCalDict():
             if len(line) == 0: continue
 
             if line[0] == ' ':
-                output[len(output) - 1] += line
+                output[len(output) - 1] += line.lstrip()
             else:
-                output.append(line.rstrip(" ").lstrip(" "))
+                output.append(line)
 
         return output
 


### PR DESCRIPTION
This Pull Request resolves #8 - where the resulting JSON had whitespace being generated.

Issue: I was trimming in the wrong places.
Resolution: Moved the `lstrip()` and `rstrip()` to strings for which it made more sense.
